### PR TITLE
Add Typescript to API Routes

### DIFF
--- a/components/CurrentWeather/CurrentWeather.tsx
+++ b/components/CurrentWeather/CurrentWeather.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLazyQuery } from "@apollo/react-hooks";
-import { gql } from "apollo-boost";
+import { gql } from "@apollo/client";
 
 import { Well, PageTitle, NavLink } from "../";
 import { WeatherInfo, MaxMinTemp } from "./components";
@@ -16,7 +16,7 @@ interface Coords {
   lat: number;
 }
 
-interface CurrentWeather {
+interface Weather {
   city: string;
   coords: Coords;
   description: string;
@@ -30,6 +30,10 @@ interface CurrentWeather {
   sunset: number;
   temp: number;
   windSpeed: number;
+}
+
+interface CurrentWeatherType {
+  currentWeather: Weather;
 }
 
 const GET_CURRENT_WEATHER = gql`
@@ -59,7 +63,7 @@ const CurrentWeather = ({ location }) => {
   const { long, lat } = location;
 
   const [getCurrentWeather, { called, loading, error, data }] = useLazyQuery<
-    CurrentWeather
+    CurrentWeatherType
   >(GET_CURRENT_WEATHER, { variables: { long, lat } });
 
   useEffect(() => {

--- a/components/CurrentWeather/components/MaxMinTemp/MaxMinTemp.styles.ts
+++ b/components/CurrentWeather/components/MaxMinTemp/MaxMinTemp.styles.ts
@@ -30,7 +30,11 @@ export const Temp = styled.p`
   font-family: "Roboto", sans-serif;
 `;
 
-export const Icon = styled.div`
+interface IconProps {
+  type: string;
+}
+
+export const Icon = styled.div<IconProps>`
   width: 0;
   height: 0;
   border-left: 30px solid transparent;

--- a/components/CurrentWeather/components/WeatherInfo/WeatherInfo.tsx
+++ b/components/CurrentWeather/components/WeatherInfo/WeatherInfo.tsx
@@ -1,6 +1,6 @@
 import { BigDisplay, GranularDisplay } from "../";
 
-import { Container, MinMaxContainer } from "./WeatherInfo.styles";
+import { Container } from "./WeatherInfo.styles";
 
 const WeatherInfo = ({ weatherData }) => (
   <Container>

--- a/components/ForeCast/ForeCast.tsx
+++ b/components/ForeCast/ForeCast.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useLazyQuery } from "@apollo/react-hooks";
-import { gql } from "apollo-boost";
+import { gql } from "@apollo/client";
 
 import { Well, PageTitle, NavLink } from "../";
 import { ForeCastList } from "./components";

--- a/components/ForeCastPage/ForeCastPage.tsx
+++ b/components/ForeCastPage/ForeCastPage.tsx
@@ -3,7 +3,12 @@ import { CurrentWeather, Well, TitleBar, ForeCast } from "../";
 import { PageLayout, Title } from "./ForeCastPage.styles";
 
 const ForeCastPage = () => {
-  const [location, setLocation] = useState();
+  interface Location {
+    long: number;
+    lat: number;
+  }
+
+  const [location, setLocation] = useState<Location>();
   const [geoApiExists, setGeoApiExists] = useState(true);
   const [geoPermission, setGeoPermission] = useState(true);
 

--- a/components/HomePage/HomePage.tsx
+++ b/components/HomePage/HomePage.tsx
@@ -3,7 +3,12 @@ import { CurrentWeather, Well, TitleBar } from "../";
 import { PageLayout, Title } from "./HomePage.styles";
 
 const HomePage = () => {
-  const [location, setLocation] = useState();
+  interface Location {
+    long: number;
+    lat: number;
+  }
+
+  const [location, setLocation] = useState<Location>();
   const [geoApiExists, setGeoApiExists] = useState(true);
   const [geoPermission, setGeoPermission] = useState(true);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,31 +1881,6 @@
         }
       }
     },
-    "apollo-boost": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.9.tgz",
-      "integrity": "sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-cache-inmemory": "^1.6.6",
-        "apollo-client": "^2.6.10",
-        "apollo-link": "^1.0.6",
-        "apollo-link-error": "^1.0.3",
-        "apollo-link-http": "^1.3.1",
-        "graphql-tag": "^2.4.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
-      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
-      "requires": {
-        "apollo-utilities": "^1.3.4",
-        "tslib": "^1.10.0"
-      }
-    },
     "apollo-cache-control": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz",
@@ -1913,52 +1888,6 @@
       "requires": {
         "apollo-server-env": "^2.4.5",
         "apollo-server-plugin-base": "^0.9.1"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
-      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
-      "requires": {
-        "apollo-cache": "^1.3.5",
-        "apollo-utilities": "^1.3.4",
-        "optimism": "^0.10.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "@wry/context": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-          "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
-          "requires": {
-            "@types/node": ">=6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "optimism": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
-          "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
-          "requires": {
-            "@wry/context": "^0.4.0"
-          }
-        }
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
-      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.5",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.4",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.0"
       }
     },
     "apollo-datasource": {
@@ -2023,36 +1952,6 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-error": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.13.tgz",
-      "integrity": "sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
-      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
-      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
       }
     },
     "apollo-server-caching": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@apollo/client": "^3.1.3",
     "@apollo/react-hooks": "^4.0.0",
-    "apollo-boost": "^0.4.9",
     "apollo-server-micro": "^2.16.1",
     "babel-plugin-styled-components": "^1.11.1",
     "graphql": "^15.3.0",

--- a/pages/api/graphql-data.ts
+++ b/pages/api/graphql-data.ts
@@ -1,9 +1,14 @@
 import { ApolloServer, gql } from "apollo-server-micro";
-import { CurrentWeather, ForecastWeather } from "../../utils/types";
+import {
+  CurrentWeatherType,
+  ForecastWeatherType,
+  WeatherApiType,
+} from "../../utils/types";
 import { baseApiUrl } from "../../utils/endpoints";
 import { fetchWeatherData } from "../../utils/fetchWeatherData";
 
-const getCurrentWeather = async args => await fetchWeatherData(args, "weather");
+const getCurrentWeather = async (args): Promise<WeatherApiType> =>
+  await fetchWeatherData(args, "weather");
 
 const getForecast = async args =>
   await fetchWeatherData(args, "onecall", "current,hourly,minutely");
@@ -78,7 +83,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    currentWeather: async (parent, args): Promise<Array<CurrentWeather>> => {
+    currentWeather: async (parent, args): Promise<CurrentWeatherType> => {
       const currentWeatherData = await getCurrentWeather(args);
 
       const {
@@ -107,8 +112,7 @@ const resolvers = {
       };
     },
 
-    // fiveDayForecast: async (parent, args): Promise<Array<ForecastWeather>> => {
-    fiveDayForecast: async (parent, args) => {
+    fiveDayForecast: async (parent, args): Promise<ForecastWeatherType> => {
       const weatherForecast = await getForecast(args);
 
       const { lat, lon, timezone, daily } = weatherForecast;

--- a/pages/five-day-forecast.tsx
+++ b/pages/five-day-forecast.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from "@apollo/react-hooks";
-import ApolloClient, { gql } from "apollo-boost";
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
 import { ForeCastPage } from "../components";
 
 const Home = ({ data, host, protocol }) => {
@@ -7,6 +7,7 @@ const Home = ({ data, host, protocol }) => {
 
   const client = new ApolloClient({
     uri,
+    cache: new InMemoryCache(),
   });
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from "@apollo/react-hooks";
-import ApolloClient, { gql } from "apollo-boost";
+import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
 import { HomePage } from "../components";
 
 const Home = ({ data, host, protocol }) => {
@@ -7,6 +7,7 @@ const Home = ({ data, host, protocol }) => {
 
   const client = new ApolloClient({
     uri,
+    cache: new InMemoryCache(),
   });
 
   return (

--- a/utils/fetchWeatherData.ts
+++ b/utils/fetchWeatherData.ts
@@ -1,7 +1,8 @@
 import fetch from "isomorphic-unfetch";
 import { baseApiUrl } from "./endpoints";
+import { WeatherApiType } from "./types";
 
-export const fetchWeatherData = async (coords, dataType, exclude) => {
+export const fetchWeatherData = async (coords, dataType, exclude = "") => {
   const API_KEY = process.env.API_KEY;
 
   const url = `${baseApiUrl}/${dataType}?lat=${coords.lat}&lon=${coords.long}${

--- a/utils/types/CommonTypes.ts
+++ b/utils/types/CommonTypes.ts
@@ -3,6 +3,32 @@ export interface Coord {
   lat: number;
 }
 
+export interface Temp {
+  day: number;
+  min: number;
+  max: number;
+  night: number;
+  eve: number;
+  morn: number;
+}
+
+export interface Daily {
+  dt: number;
+  sunrise: number;
+  sunset: number;
+  temp: Temp;
+  feels_like: Temp;
+  pressure: number;
+  humidity: number;
+  dew_point: number;
+  wind_speed: number;
+  wind_deg: number;
+  weather: Array<Weather>;
+  clouds: number;
+  pop: number;
+  uvi: number;
+}
+
 export interface Weather {
   id: number;
   main: string;
@@ -11,7 +37,7 @@ export interface Weather {
 }
 
 export interface WeatherArr {
-  weather: [Weather];
+  weather: Weather[];
 }
 
 export interface Main {

--- a/utils/types/CurrentWeatherType.ts
+++ b/utils/types/CurrentWeatherType.ts
@@ -1,0 +1,25 @@
+import {
+  Coord,
+  Weather,
+  WeatherArr,
+  Main,
+  Wind,
+  Clouds,
+  Sys,
+} from "./CommonTypes";
+
+export interface CurrentWeatherType {
+  city: string;
+  coords: Coord;
+  description: string;
+  feelsLike: number;
+  humidity: number;
+  icon: string;
+  maxTemp: number;
+  minTemp: number;
+  pressure: number;
+  sunrise: number;
+  sunset: number;
+  temp: number;
+  windSpeed: number;
+}

--- a/utils/types/ForecastWeather.ts
+++ b/utils/types/ForecastWeather.ts
@@ -1,1 +1,0 @@
-export interface ForecastWeather {}

--- a/utils/types/ForecastWeatherType.ts
+++ b/utils/types/ForecastWeatherType.ts
@@ -1,0 +1,8 @@
+import { Weather, Daily, Temp } from "./CommonTypes";
+
+export interface ForecastWeatherType {
+  lat: number;
+  lon: number;
+  timezone: string;
+  daily: Daily;
+}

--- a/utils/types/WeatherApiType.ts
+++ b/utils/types/WeatherApiType.ts
@@ -1,18 +1,11 @@
-import {
-  Coord,
-  Weather,
-  WeatherArr,
-  Main,
-  Wind,
-  Clouds,
-  Sys,
-} from "./CommonTypes";
+import { Coord, Clouds, Weather, Main, Wind, Sys } from "./CommonTypes";
 
-export interface CurrentWeather {
+export interface WeatherApiType {
   coord: Coord;
-  weather: Weather;
+  weather: Weather[];
   base: string;
   main: Main;
+  visibility: number;
   wind: Wind;
   clouds: Clouds;
   dt: number;

--- a/utils/types/index.js
+++ b/utils/types/index.js
@@ -1,2 +1,3 @@
-export { CurrentWeather } from "./CurrentWeather";
-export { ForecastWeather } from "./ForecastWeather";
+export { CurrentWeatherType } from "./CurrentWeatherType";
+export { ForecastWeatherType } from "./ForecastWeatherType";
+export { WeatherApiType } from "./WeatherApiType";


### PR DESCRIPTION
# Description

* Add TS type checking for API Routes 
* Add type checking for resolvers
* Fix typescript errors around app
* Changed `apollo-boost` to `@apollo/client` since sufficient TS support doesn't exist in `apollo-boost`

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-   [x] Typescript checker in terminal using `npm run build`
